### PR TITLE
Consolidate Validation logic into a shared builder for re-use across modules

### DIFF
--- a/CodeHub.sln
+++ b/CodeHub.sln
@@ -56,6 +56,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeHub.Platform.GitHub", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeHub.Platform.GitLab", "src\backend\CodeHub.Platform.GitLab\CodeHub.Platform.GitLab.csproj", "{7014F74C-506D-4DC3-85DC-DF14EC446FB4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeHub.Platform.GitHub.Tests", "src\backend\CodeHub.Platform.GitHub.Tests\CodeHub.Platform.GitHub.Tests.csproj", "{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeHub.Platform.GitLab.Tests", "src\backend\CodeHub.Platform.GitLab.Tests\CodeHub.Platform.GitLab.Tests.csproj", "{6A915CB9-8153-433B-9DC1-0AFE159486B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +106,14 @@ Global
 		{7014F74C-506D-4DC3-85DC-DF14EC446FB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7014F74C-506D-4DC3-85DC-DF14EC446FB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7014F74C-506D-4DC3-85DC-DF14EC446FB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A915CB9-8153-433B-9DC1-0AFE159486B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A915CB9-8153-433B-9DC1-0AFE159486B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A915CB9-8153-433B-9DC1-0AFE159486B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A915CB9-8153-433B-9DC1-0AFE159486B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -120,5 +132,7 @@ Global
 		{4D69214A-521E-413C-8732-A228A50753DD} = {3AC7FEA5-756C-45E1-8988-16170C26B898}
 		{8AFCA3A8-0CDB-4FF7-B484-803EA74E94D5} = {6BBAFA79-C6EC-4415-8249-3AF0BF69A8F8}
 		{7014F74C-506D-4DC3-85DC-DF14EC446FB4} = {6BBAFA79-C6EC-4415-8249-3AF0BF69A8F8}
+		{8BD76230-630B-42A1-AAB3-E3A6E2EAB8A1} = {3AC7FEA5-756C-45E1-8988-16170C26B898}
+		{6A915CB9-8153-433B-9DC1-0AFE159486B7} = {3AC7FEA5-756C-45E1-8988-16170C26B898}
 	EndGlobalSection
 EndGlobal

--- a/src/backend/CodeHub.Platform.Azure/Models/AzureSettings.cs
+++ b/src/backend/CodeHub.Platform.Azure/Models/AzureSettings.cs
@@ -1,14 +1,7 @@
-﻿namespace CodeHub.Platform.Azure.Models;
+﻿using CodeHub.Shared.Models;
 
-internal sealed record AzureSettings
+namespace CodeHub.Platform.Azure.Models;
+
+internal sealed class AzureSettings : Settings
 {
-    public required bool IsEnabled { get; init; }
-
-    public static AzureSettings CreateDisabled()
-    {
-        return new AzureSettings
-        {
-            IsEnabled = false
-        };
-    }
 }

--- a/src/backend/CodeHub.Platform.Azure/Validation/AzureSettingsValidator.cs
+++ b/src/backend/CodeHub.Platform.Azure/Validation/AzureSettingsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CodeHub.Platform.Azure.Models;
+using CodeHub.Shared.Validation;
 using Microsoft.Extensions.Configuration;
 
 namespace CodeHub.Platform.Azure.Validation;
@@ -7,24 +8,9 @@ internal static class AzureSettingsValidator
 {
     internal static AzureSettings GetValidSettings(IConfiguration configuration)
     {
-        var settingsSection = configuration.GetSection(nameof(AzureSettings));
-
-        if (!settingsSection.Exists())
-        {
-            throw new InvalidOperationException("Azure settings section is missing");
-        }
-
-        var isEnabledSection = settingsSection.GetSection(nameof(AzureSettings.IsEnabled));
-        var isEnabled = settingsSection.GetValue<bool>(nameof(AzureSettings.IsEnabled));
-
-        if (!isEnabledSection.Exists() || !isEnabled)
-        {
-            return AzureSettings.CreateDisabled();
-        }
-
-        return new AzureSettings
-        {
-            IsEnabled = isEnabled
-        };
+        return new ValidationBuilder<AzureSettings>(configuration)
+            .SectionExists(nameof(AzureSettings))
+            .CheckEnabled(x => x.IsEnabled, nameof(AzureSettings.IsEnabled))
+            .Build();
     }
 }

--- a/src/backend/CodeHub.Platform.AzureDevOps/Models/AzureDevOpsSettings.cs
+++ b/src/backend/CodeHub.Platform.AzureDevOps/Models/AzureDevOpsSettings.cs
@@ -1,18 +1,9 @@
-﻿namespace CodeHub.Platform.AzureDevOps.Models;
+﻿using CodeHub.Shared.Models;
 
-internal sealed record AzureDevOpsSettings
+namespace CodeHub.Platform.AzureDevOps.Models;
+
+internal sealed class AzureDevOpsSettings : Settings
 {
-    public required string PersonalAccessToken { get; init; }
-    public required string Organization { get; init; }
-    public required bool IsEnabled { get; init; }
-
-    public static AzureDevOpsSettings CreateDisabled()
-    {
-        return new AzureDevOpsSettings
-        {
-            IsEnabled = false,
-            PersonalAccessToken = string.Empty,
-            Organization = string.Empty,
-        };
-    }
+    public string PersonalAccessToken { get; init; } = string.Empty;
+    public string Organization { get; init; } = string.Empty;
 }

--- a/src/backend/CodeHub.Platform.AzureDevOps/Validation/AzureDevOpsSettingsValidator.cs
+++ b/src/backend/CodeHub.Platform.AzureDevOps/Validation/AzureDevOpsSettingsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CodeHub.Platform.AzureDevOps.Models;
+using CodeHub.Shared.Validation;
 using Microsoft.Extensions.Configuration;
 
 namespace CodeHub.Platform.AzureDevOps.Validation;
@@ -7,39 +8,11 @@ internal static class AzureDevOpsSettingsValidator
 {
     internal static AzureDevOpsSettings GetValidSettings(IConfiguration configuration)
     {
-        var settingsSection = configuration.GetSection(nameof(AzureDevOpsSettings));
-
-        if (!settingsSection.Exists())
-        {
-            throw new InvalidOperationException("Azure DevOps settings section is missing.");
-        }
-
-        var isEnabledSection = settingsSection.GetSection(nameof(AzureDevOpsSettings.IsEnabled));
-        var isEnabled = settingsSection.GetValue<bool>(nameof(AzureDevOpsSettings.IsEnabled));
-
-        if (!isEnabledSection.Exists() || !isEnabled)
-        {
-            return AzureDevOpsSettings.CreateDisabled();
-        }
-
-        var organization = settingsSection.GetValue<string>(nameof(AzureDevOpsSettings.Organization));
-        var personalAccessToken = settingsSection.GetValue<string>(nameof(AzureDevOpsSettings.PersonalAccessToken));
-
-        if (string.IsNullOrEmpty(organization))
-        {
-            throw new InvalidOperationException("Organization configuration is missing");
-        }
-
-        if (string.IsNullOrEmpty(personalAccessToken))
-        {
-            throw new InvalidOperationException("Personal Access Token configuration is missing");
-        }
-
-        return new AzureDevOpsSettings
-        {
-            Organization = organization,
-            PersonalAccessToken = personalAccessToken,
-            IsEnabled = isEnabled
-        };
+        return new ValidationBuilder<AzureDevOpsSettings>(configuration)
+            .SectionExists(nameof(AzureDevOpsSettings))
+            .CheckEnabled(x => x.IsEnabled, nameof(AzureDevOpsSettings.IsEnabled))
+            .CheckValue(x => x.Organization, nameof(AzureDevOpsSettings.Organization))
+            .CheckValue(x => x.PersonalAccessToken, nameof(AzureDevOpsSettings.PersonalAccessToken))
+            .Build();
     }
 }

--- a/src/backend/CodeHub.Platform.GitHub.Tests/CodeHub.Platform.GitHub.Tests.csproj
+++ b/src/backend/CodeHub.Platform.GitHub.Tests/CodeHub.Platform.GitHub.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="coverlet.msbuild"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CodeHub.Platform.GitHub\CodeHub.Platform.GitHub.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/backend/CodeHub.Platform.GitHub.Tests/Extensions/GitHubExtensionsTests.cs
+++ b/src/backend/CodeHub.Platform.GitHub.Tests/Extensions/GitHubExtensionsTests.cs
@@ -1,0 +1,115 @@
+﻿using CodeHub.Platform.GitHub.Extensions;
+using CodeHub.Platform.GitHub.Services;
+using CodeHub.Shared.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CodeHub.Platform.GitHub.Tests.Extensions;
+
+public sealed class GitHubExtensionsTests
+{
+    [Fact]
+    public void RegisterGitHubServices_WhenEnabledWithValidSettings_RegistersCorrectServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidGitHubConfiguration(true))
+            .Build();
+
+        // Act
+        serviceCollection.RegisterGitHub(configuration);
+
+        // Assert
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IDiscoveryService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitHubDiscoveryService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IGitHubService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitHubService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IGitHubConnectionService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitHubConnectionService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IMemoryCache) &&
+                       service.ImplementationType == typeof(MemoryCache));
+    }
+
+    [Fact]
+    public void RegisterGitHubServices_WhenDisabledWithValidSettings_DoesNotRegisterServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidGitHubConfiguration(false))
+            .Build();
+
+        // Act
+        var serviceCountBefore = serviceCollection.Count;
+        serviceCollection.RegisterGitHub(configuration);
+
+        // Assert
+        Assert.Equal(serviceCountBefore, serviceCollection.Count);
+    }
+
+    [Fact]
+    public void RegisterGitHubServices_WhenDisabledWithValidSettingsButNotWholeSection_DoesNotRegisterServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidWithoutOtherGitHubConfiguration(false))
+            .Build();
+
+        // Act
+        var serviceCountBefore = serviceCollection.Count;
+        serviceCollection.RegisterGitHub(configuration);
+
+        // Assert
+        Assert.Equal(serviceCountBefore, serviceCollection.Count);
+    }
+
+
+    [Fact]
+    public void RegisterGitHubServices_WhenEnabledButCalledWithMissingSettings_ThrowsException()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetInvalidGitHubSettings(true))
+            .Build();
+
+        // Act + Assert
+        Assert.Throws<InvalidOperationException>(() => serviceCollection.RegisterGitHub(configuration));
+    }
+
+    private static Dictionary<string, string?> GetValidGitHubConfiguration(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitHubSettings:AgentName", "TestAgentName" },
+            { "GitHubSettings:Token", "TestToken" },
+            { "GitHubSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+
+    private static Dictionary<string, string?> GetValidWithoutOtherGitHubConfiguration(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitHubSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+
+    private static Dictionary<string, string?> GetInvalidGitHubSettings(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitHubSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+}

--- a/src/backend/CodeHub.Platform.GitHub/CodeHub.Platform.GitHub.csproj
+++ b/src/backend/CodeHub.Platform.GitHub/CodeHub.Platform.GitHub.csproj
@@ -1,11 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="Octokit" />
+        <PackageReference Include="Octokit"/>
         <PackageReference Include="System.Text.Json"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory"/>
     </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\CodeHub.Shared\CodeHub.Shared.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="CodeHub.Platform.GitHub.Tests"/>
     </ItemGroup>
 </Project>

--- a/src/backend/CodeHub.Platform.GitHub/Models/GitHubSettings.cs
+++ b/src/backend/CodeHub.Platform.GitHub/Models/GitHubSettings.cs
@@ -1,18 +1,9 @@
-﻿namespace CodeHub.Platform.GitHub.Models;
+﻿using CodeHub.Shared.Models;
 
-internal sealed record GitHubSettings
+namespace CodeHub.Platform.GitHub.Models;
+
+internal sealed class GitHubSettings : Settings
 {
-    public required string AgentName { get; init; }
-    public required string Token { get; init; }
-    public required bool IsEnabled { get; init; }
-
-    public static GitHubSettings CreateDisabled()
-    {
-        return new GitHubSettings
-        {
-            IsEnabled = false,
-            AgentName = string.Empty,
-            Token = string.Empty
-        };
-    }
+    public string AgentName { get; init; } = string.Empty;
+    public string Token { get; init; } = string.Empty;
 }

--- a/src/backend/CodeHub.Platform.GitHub/Validator/GitHubSettingsValidator.cs
+++ b/src/backend/CodeHub.Platform.GitHub/Validator/GitHubSettingsValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CodeHub.Platform.GitHub.Models;
+using CodeHub.Shared.Validation;
 using Microsoft.Extensions.Configuration;
 
 namespace CodeHub.Platform.GitHub.Validator;
@@ -7,6 +8,13 @@ internal static class GitHubSettingsValidator
 {
     internal static GitHubSettings GetValidSettings(IConfiguration configuration)
     {
+        //return new ValidationBuilder<GitHubSettings>(configuration)
+        //    .SectionExists(nameof(GitHubSettings))
+        //    .CheckEnabled(x => x.IsEnabled, nameof(GitHubSettings.IsEnabled))
+        //    .CheckValue(x => x.AgentName, nameof(GitHubSettings.AgentName))
+        //    .CheckValue(x => x.Token, nameof(GitHubSettings.Token))
+        //    .Build();
+        
         var settingsSection = configuration.GetSection(nameof(GitHubSettings));
 
         if (!settingsSection.Exists())

--- a/src/backend/CodeHub.Platform.GitHub/Validator/GitHubSettingsValidator.cs
+++ b/src/backend/CodeHub.Platform.GitHub/Validator/GitHubSettingsValidator.cs
@@ -8,41 +8,11 @@ internal static class GitHubSettingsValidator
 {
     internal static GitHubSettings GetValidSettings(IConfiguration configuration)
     {
-        //return new ValidationBuilder<GitHubSettings>(configuration)
-        //    .SectionExists(nameof(GitHubSettings))
-        //    .CheckEnabled(x => x.IsEnabled, nameof(GitHubSettings.IsEnabled))
-        //    .CheckValue(x => x.AgentName, nameof(GitHubSettings.AgentName))
-        //    .CheckValue(x => x.Token, nameof(GitHubSettings.Token))
-        //    .Build();
-        
-        var settingsSection = configuration.GetSection(nameof(GitHubSettings));
-
-        if (!settingsSection.Exists())
-        {
-            throw new InvalidOperationException("GitHub settings section is missing");
-        }
-
-        var isEnabledSection = settingsSection.GetSection(nameof(GitHubSettings.IsEnabled));
-        var isEnabled = settingsSection.GetValue<bool>(nameof(GitHubSettings.IsEnabled));
-
-        if (!isEnabledSection.Exists() || !isEnabled)
-        {
-            return GitHubSettings.CreateDisabled();
-        }
-
-        var agentName = settingsSection.GetValue<string>(nameof(GitHubSettings.AgentName));
-        var token = settingsSection.GetValue<string>(nameof(GitHubSettings.Token));
-
-        if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(agentName))
-        {
-            throw new InvalidOperationException("");
-        }
-
-        return new GitHubSettings
-        {
-            AgentName = agentName,
-            Token = token,
-            IsEnabled = isEnabled,
-        };
+        return new ValidationBuilder<GitHubSettings>(configuration)
+            .SectionExists(nameof(GitHubSettings))
+            .CheckEnabled(x => x.IsEnabled, nameof(GitHubSettings.IsEnabled))
+            .CheckValue(x => x.AgentName, nameof(GitHubSettings.AgentName))
+            .CheckValue(x => x.Token, nameof(GitHubSettings.Token))
+            .Build();
     }
 }

--- a/src/backend/CodeHub.Platform.GitLab.Tests/CodeHub.Platform.GitLab.Tests.csproj
+++ b/src/backend/CodeHub.Platform.GitLab.Tests/CodeHub.Platform.GitLab.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="coverlet.msbuild"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\CodeHub.Platform.GitLab\CodeHub.Platform.GitLab.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/backend/CodeHub.Platform.GitLab.Tests/Extensions/GitLabExtensionsTests.cs
+++ b/src/backend/CodeHub.Platform.GitLab.Tests/Extensions/GitLabExtensionsTests.cs
@@ -1,0 +1,115 @@
+﻿using CodeHub.Platform.GitLab.Extensions;
+using CodeHub.Platform.GitLab.Services;
+using CodeHub.Shared.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CodeHub.Platform.GitLab.Tests.Extensions;
+
+public sealed class GitLabExtensionsTests
+{
+    [Fact]
+    public void RegisterGitLabServices_WhenEnabledWithValidSettings_RegistersCorrectServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidGitLabConfiguration(true))
+            .Build();
+
+        // Act
+        serviceCollection.RegisterGitLab(configuration);
+
+        // Assert
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IDiscoveryService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitLabDiscoveryService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IGitLabService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitLabService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IGitLabConnectionService) &&
+                       service.Lifetime == ServiceLifetime.Singleton &&
+                       service.ImplementationType == typeof(GitLabConnectionService));
+        Assert.Contains(serviceCollection,
+            service => service.ServiceType == typeof(IMemoryCache) &&
+                       service.ImplementationType == typeof(MemoryCache));
+    }
+
+    [Fact]
+    public void RegisterGitLabServices_WhenDisabledWithValidSettings_DoesNotRegisterServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidGitLabConfiguration(false))
+            .Build();
+
+        // Act
+        var serviceCountBefore = serviceCollection.Count;
+        serviceCollection.RegisterGitLab(configuration);
+
+        // Assert
+        Assert.Equal(serviceCountBefore, serviceCollection.Count);
+    }
+
+    [Fact]
+    public void RegisterGitLabServices_WhenDisabledWithValidSettingsButNotWholeSection_DoesNotRegisterServices()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetValidWithoutOtherGitLabConfiguration(false))
+            .Build();
+
+        // Act
+        var serviceCountBefore = serviceCollection.Count;
+        serviceCollection.RegisterGitLab(configuration);
+
+        // Assert
+        Assert.Equal(serviceCountBefore, serviceCollection.Count);
+    }
+
+
+    [Fact]
+    public void RegisterGitLabServices_WhenEnabledButCalledWithMissingSettings_ThrowsException()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(GetInvalidGitLabSettings(true))
+            .Build();
+
+        // Act + Assert
+        Assert.Throws<InvalidOperationException>(() => serviceCollection.RegisterGitLab(configuration));
+    }
+
+    private static Dictionary<string, string?> GetValidGitLabConfiguration(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitLabSettings:HostUrl", "TestHostUrl" },
+            { "GitLabSettings:Token", "TestToken" },
+            { "GitLabSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+
+    private static Dictionary<string, string?> GetValidWithoutOtherGitLabConfiguration(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitLabSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+
+    private static Dictionary<string, string?> GetInvalidGitLabSettings(bool enabled)
+    {
+        return new Dictionary<string, string?>
+        {
+            { "GitLabSettings:IsEnabled", enabled.ToString() }
+        };
+    }
+}

--- a/src/backend/CodeHub.Platform.GitLab/CodeHub.Platform.GitLab.csproj
+++ b/src/backend/CodeHub.Platform.GitLab/CodeHub.Platform.GitLab.csproj
@@ -4,7 +4,12 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions"/>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory"/>
     </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\CodeHub.Shared\CodeHub.Shared.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="CodeHub.Platform.GitLab.Tests"/>
     </ItemGroup>
 </Project>

--- a/src/backend/CodeHub.Platform.GitLab/Models/GitLabSettings.cs
+++ b/src/backend/CodeHub.Platform.GitLab/Models/GitLabSettings.cs
@@ -1,18 +1,9 @@
+using CodeHub.Shared.Models;
+
 namespace CodeHub.Platform.GitLab.Models;
 
-internal sealed record GitLabSettings
+internal sealed class GitLabSettings : Settings
 {
-    public required string HostUrl { get; init; }
-    public required string Token { get; init; }
-    public required bool IsEnabled { get; init; }
-
-    public static GitLabSettings CreateDisabled()
-    {
-        return new GitLabSettings
-        {
-            IsEnabled = false,
-            HostUrl = string.Empty,
-            Token = string.Empty
-        };
-    }
+    public string HostUrl { get; init; } = string.Empty;
+    public string Token { get; init; } = string.Empty;
 }

--- a/src/backend/CodeHub.Platform.GitLab/Validator/GitLabSettingsValidator.cs
+++ b/src/backend/CodeHub.Platform.GitLab/Validator/GitLabSettingsValidator.cs
@@ -1,4 +1,5 @@
 using CodeHub.Platform.GitLab.Models;
+using CodeHub.Shared.Validation;
 using Microsoft.Extensions.Configuration;
 
 namespace CodeHub.Platform.GitLab.Validator;
@@ -7,34 +8,11 @@ internal static class GitLabSettingsValidator
 {
     internal static GitLabSettings GetValidSettings(IConfiguration configuration)
     {
-        var settingsSection = configuration.GetSection(nameof(GitLabSettings));
-
-        if (!settingsSection.Exists())
-        {
-            throw new InvalidOperationException("GitLab settings section is missing");
-        }
-
-        var isEnabledSection = settingsSection.GetSection(nameof(GitLabSettings.IsEnabled));
-        var isEnabled = settingsSection.GetValue<bool>(nameof(GitLabSettings.IsEnabled));
-
-        if (!isEnabledSection.Exists() || !isEnabled)
-        {
-            return GitLabSettings.CreateDisabled();
-        }
-
-        var hostUrl = settingsSection.GetValue<string>(nameof(GitLabSettings.HostUrl));
-        var token = settingsSection.GetValue<string>(nameof(GitLabSettings.Token));
-
-        if (string.IsNullOrEmpty(token) || string.IsNullOrEmpty(hostUrl))
-        {
-            throw new InvalidOperationException("");
-        }
-
-        return new GitLabSettings
-        {
-            HostUrl = hostUrl,
-            Token = token,
-            IsEnabled = isEnabled,
-        };
+        return new ValidationBuilder<GitLabSettings>(configuration)
+            .SectionExists(nameof(GitLabSettings))
+            .CheckEnabled(x => x.IsEnabled, nameof(GitLabSettings.IsEnabled))
+            .CheckValue(x => x.HostUrl, nameof(GitLabSettings.HostUrl))
+            .CheckValue(x => x.Token, nameof(GitLabSettings.Token))
+            .Build();
     }
 }

--- a/src/backend/CodeHub.Shared/Models/Settings.cs
+++ b/src/backend/CodeHub.Shared/Models/Settings.cs
@@ -1,0 +1,6 @@
+namespace CodeHub.Shared.Models;
+
+public abstract class Settings
+{
+    public bool IsEnabled { get; init; }
+}

--- a/src/backend/CodeHub.Shared/Validation/IValidationBuilder.cs
+++ b/src/backend/CodeHub.Shared/Validation/IValidationBuilder.cs
@@ -1,0 +1,12 @@
+using System.Linq.Expressions;
+using CodeHub.Shared.Models;
+
+namespace CodeHub.Shared.Validation;
+
+public interface IValidationBuilder<T> where T : Settings, new()
+{
+    T Build();
+    ValidationBuilder<T> SectionExists(string sectionKey);
+    ValidationBuilder<T> CheckEnabled(Expression<Func<T, bool>> enabledProperty, string enabledKey);
+    ValidationBuilder<T> CheckValue<TProp>(Expression<Func<T, TProp>> property, string valueKey);
+}

--- a/src/backend/CodeHub.Shared/Validation/ValidationBuilder.cs
+++ b/src/backend/CodeHub.Shared/Validation/ValidationBuilder.cs
@@ -1,0 +1,82 @@
+using System.Linq.Expressions;
+using CodeHub.Shared.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace CodeHub.Shared.Validation;
+
+public sealed class ValidationBuilder<T> where T : Settings, new()
+{
+    private readonly IConfiguration _configuration;
+    private IConfigurationSection? _settingsSection;
+    private readonly T _settings = new();
+
+    public ValidationBuilder(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public T Build() => _settings;
+
+    public ValidationBuilder<T> SectionExists(string sectionKey)
+    {
+        _settingsSection = _configuration.GetSection(sectionKey);
+
+        if (!_settingsSection.Exists())
+        {
+            throw new InvalidOperationException($"{sectionKey} settings section is missing.");
+        }
+
+        return this;
+    }
+
+    public ValidationBuilder<T> CheckEnabled(Expression<Func<T, bool>> enabledProperty, string enabledKey)
+    {
+        ArgumentNullException.ThrowIfNull(_settingsSection, "Settings Section is missing.");
+
+        var isEnabledSection = _settingsSection.GetSection(enabledKey);
+        var isEnabled = _settingsSection.GetValue<bool>(enabledKey);
+
+        if (!isEnabledSection.Exists() || !isEnabled)
+        {
+            SetProperty(enabledProperty, false);
+        }
+        else
+        {
+            SetProperty(enabledProperty, true);
+        }
+
+        return this;
+    }
+
+    public ValidationBuilder<T> CheckValue<TProp>(Expression<Func<T, TProp>> property, string valueKey)
+    {
+        ArgumentNullException.ThrowIfNull(_settingsSection, "Settings Section is missing.");
+
+        if (!_settings.IsEnabled)
+        {
+            return this;
+        }
+
+        var value = _settingsSection.GetValue<TProp>(valueKey);
+
+        if (value == null || (value is string str && string.IsNullOrEmpty(str)))
+        {
+            throw new InvalidOperationException($"{valueKey} configuration is missing");
+        }
+
+        SetProperty(property, value);
+        return this;
+    }
+
+    private void SetProperty<TProp>(Expression<Func<T, TProp>> propertyExpression, TProp value)
+    {
+        if (propertyExpression.Body is MemberExpression { Member: System.Reflection.PropertyInfo propertyInfo })
+        {
+            propertyInfo.SetValue(_settings, value);
+        }
+        else
+        {
+            throw new InvalidOperationException("Invalid property expression");
+        }
+    }
+}


### PR DESCRIPTION
Consolidate Validation logic into a shared builder for re-use across modules. 

- I have implemented a ValidationBuilder which allows the building and validating of settings in various formats. 
- I have introduced a class hierachy (1 level only) to allow some type constraints on the builder. Each module can be enabled / disabled, so having a shared settings hierachy makes some sense.
- Added in test coverage for github and gitlab modules for settings check